### PR TITLE
Fix "Fatal error: cannot open file `render.R`: No such file or directory"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rocker/r-rmd
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh render.R /
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,6 @@ echo "Thanks for using this GH action!"
 input_file=$1
 output_format=$2
 
+ln -s /render.R .
+
 Rscript render.R $input_file $output_format


### PR DESCRIPTION
Firstly, `render.R` must be copied into the Docker container for it to be able to use it.

Secondly, when `entrypoint` is executed it's current path is `/github/workspace`, where there is no `render.R` script, thus it is not possible to execute it. I managed to do a quickfix on it creating a soft link of `/render.R` to the working directory.

Fixes #3 